### PR TITLE
Detect SlowBuffer on Node v0.10

### DIFF
--- a/index.js
+++ b/index.js
@@ -12,6 +12,15 @@ module.exports = function (obj) {
     (obj._isBuffer || // For Safari 5-7 (missing Object.prototype.constructor)
       (obj.constructor &&
       typeof obj.constructor.isBuffer === 'function' &&
-      obj.constructor.isBuffer(obj))
+      obj.constructor.isBuffer(obj)) ||
+      // Node v0.10
+      checkSlowBuffer(obj)
     ))
+}
+
+function checkSlowBuffer (obj) {
+  if (!obj.slice) return false;
+  var buf = obj.slice(0, 0)
+  return buf.constructor && buf.constructor.isBuffer &&
+    buf.constructor.isBuffer(obj)
 }

--- a/index.js
+++ b/index.js
@@ -19,7 +19,7 @@ module.exports = function (obj) {
 }
 
 function checkSlowBuffer (obj) {
-  if (!obj.slice) return false;
+  if (!obj.slice) return false
   var buf = obj.slice(0, 0)
   return buf.constructor && buf.constructor.isBuffer &&
     buf.constructor.isBuffer(obj)

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "zuul": "^3.0.0"
   },
   "engines": {
-    "node": ">=0.12"
+    "node": ">=0.10"
   },
   "keywords": [
     "buffer",

--- a/test/basic.js
+++ b/test/basic.js
@@ -3,6 +3,7 @@ var test = require('tape')
 
 test('is-buffer', function (t) {
   t.ok(isBuffer(new Buffer(4)), 'new Buffer(4)')
+  t.ok(isBuffer(require('buffer').SlowBuffer(100)), 'SlowBuffer(100)')
 
   t.notOk(isBuffer(undefined), 'undefined')
   t.notOk(isBuffer(null), 'null')


### PR DESCRIPTION
It turns out that `slowBuffer.slice()` returns a `Buffer` instance, which we can use to get access to `isBuffer` method.

In this patch, I am fixing `isBuffer` to correctly detect SlowBuffer on Node v0.10 and adding Node v0.10 back to supported engines in package.json

@feross please review
@phated FYI, this should fix #2 you have reported earlier this year
