### PR TITLE
Remove SlowBuffer check

### DIFF
--- a/index.js
+++ b/index.js
@@ -8,14 +8,9 @@
 // The _isBuffer check is for Safari 5-7 support, because it's missing
 // Object.prototype.constructor. Remove this eventually
 module.exports = function (obj) {
-  return obj != null && (isBuffer(obj) || isSlowBuffer(obj) || !!obj._isBuffer)
+  return obj != null && (isBuffer(obj) || !!obj._isBuffer)
 }
 
 function isBuffer (obj) {
   return !!obj.constructor && typeof obj.constructor.isBuffer === 'function' && obj.constructor.isBuffer(obj)
-}
-
-// For Node v0.10 support. Remove this eventually.
-function isSlowBuffer (obj) {
-  return typeof obj.readFloatLE === 'function' && typeof obj.slice === 'function' && isBuffer(obj.slice(0, 0))
 }


### PR DESCRIPTION
Since v0.10 has been officially unsupported [for a while now](https://github.com/nodejs/LTS).