### PR TITLE
Is it time to drop old envs?

### DIFF
--- a/index.js
+++ b/index.js
@@ -5,17 +5,6 @@
  * @license  MIT
  */
 
-// The _isBuffer check is for Safari 5-7 support, because it's missing
-// Object.prototype.constructor. Remove this eventually
-module.exports = function (obj) {
-  return obj != null && (isBuffer(obj) || isSlowBuffer(obj) || !!obj._isBuffer)
-}
-
-function isBuffer (obj) {
-  return !!obj.constructor && typeof obj.constructor.isBuffer === 'function' && obj.constructor.isBuffer(obj)
-}
-
-// For Node v0.10 support. Remove this eventually.
-function isSlowBuffer (obj) {
-  return typeof obj.readFloatLE === 'function' && typeof obj.slice === 'function' && isBuffer(obj.slice(0, 0))
+module.exports = function isBuffer (obj) {
+  return obj != null && !!obj.constructor && typeof obj.constructor.isBuffer === 'function' && obj.constructor.isBuffer(obj)
 }

--- a/test/basic.js
+++ b/test/basic.js
@@ -3,8 +3,10 @@ var isBuffer = require('../')
 var test = require('tape')
 
 test('is-buffer', function (t) {
+  /* eslint-disable node/no-deprecated-api */
   t.equal(isBuffer(new Buffer(4)), true, 'new Buffer(4)')
-  t.equal(isBuffer(buffer.SlowBuffer(100)), true, 'SlowBuffer(100)')
+  t.equal(isBuffer(new buffer.SlowBuffer(100)), true, 'new SlowBuffer(100)')
+  /* eslint-enable node/no-deprecated-api */
 
   t.equal(isBuffer(undefined), false, 'undefined')
   t.equal(isBuffer(null), false, 'null')


### PR DESCRIPTION
Node.js 0.10 has been end-of-life almost a year, and I don't think that anyone is still using it.

Safari 5-7 is also very old now and it seems like it's only used by 0.15% of the traffic that "Can I use" has gathered. (ref: http://caniuse.com/usage-table)

(this should probably be a major change though since we are breaking backwards compat for these envs)