### PR TITLE
Update README for latest Buffer support

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ npm install is-buffer
 var isBuffer = require('is-buffer')
 
 isBuffer(new Buffer(4)) // true
-isBuffer(Buffer.from([4])) //true
+isBuffer(Buffer.alloc(4)) //true
 
 isBuffer(undefined) // false
 isBuffer(null) // false

--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ npm install is-buffer
 var isBuffer = require('is-buffer')
 
 isBuffer(new Buffer(4)) // true
+isBuffer(Buffer.from([4])) //true
 
 isBuffer(undefined) // false
 isBuffer(null) // false

--- a/test/basic.js
+++ b/test/basic.js
@@ -2,6 +2,7 @@ var isBuffer = require('../')
 var test = require('tape')
 
 test('is-buffer', function (t) {
+  t.equal(isBuffer(Buffer.from([4])), true, 'Buffer.from([4])')
   t.equal(isBuffer(Buffer.alloc(4)), true, 'Buffer.alloc(4)')
   t.equal(isBuffer(Buffer.allocUnsafeSlow(100)), true, 'Buffer.allocUnsafeSlow(100)')
   t.equal(isBuffer(undefined), false, 'undefined')


### PR DESCRIPTION
Update README because latest nodejs "new Buffer(array)" is being deprecated. So used Buffer.from as an example. Also Update test cases.

Thanks
